### PR TITLE
feat: create units view page with filterable carbon data

### DIFF
--- a/src/renderer/api/cadt/v1/tonsCo2.api.ts
+++ b/src/renderer/api/cadt/v1/tonsCo2.api.ts
@@ -1,3 +1,4 @@
+import { TonsCo2 } from '@/schemas/TonsCo2.schema';
 import { cadtApi } from './index';
 
 interface TonsCo2Params {
@@ -11,7 +12,7 @@ interface TonsCo2Params {
 }
 
 interface TonsCo2Response {
-  data: any;
+  data: TonsCo2[];
 }
 
 const tonsCo2Api = cadtApi.injectEndpoints({

--- a/src/renderer/api/cadt/v1/tonsCo2.api.ts
+++ b/src/renderer/api/cadt/v1/tonsCo2.api.ts
@@ -1,0 +1,79 @@
+import { cadtApi } from './index';
+
+interface TonsCo2Params {
+  unitStatus?: string;
+  unitStatusList?: string[];
+  vintageYearRangeStart?: string;
+  vintageYearRangeEnd?: string;
+  vintageYear?: string;
+  unitType?: string;
+  unitTypeList?: string[];
+}
+
+interface TonsCo2Response {
+  data: any;
+}
+
+const tonsCo2Api = cadtApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getTonsCo2: builder.query<TonsCo2Response, TonsCo2Params>({
+      query: ({
+        unitStatus,
+        unitStatusList,
+        vintageYearRangeStart,
+        vintageYearRangeEnd,
+        vintageYear,
+        unitType,
+        unitTypeList,
+      }: TonsCo2Params) => {
+        const params: TonsCo2Params = {};
+
+        if (unitStatus && unitStatusList) {
+          throw new Error('Either unitStatus or unitStatusList must be provided, but not both.');
+        }
+
+        if (unitType && unitTypeList) {
+          throw new Error('Either unitType or unitTypeList must be provided, but not both.');
+        }
+
+        if ((vintageYearRangeStart && !vintageYearRangeEnd) || (!vintageYearRangeStart && vintageYearRangeEnd)) {
+          throw new Error('vintageYearRangeStart and vintageYearRangeEnd must be provided together.');
+        }
+
+        if (vintageYear && (vintageYearRangeStart || vintageYearRangeEnd)) {
+          throw new Error(
+            'Either vintageYear or vintageYearRange (vintageYearRangeStart and vintageYearRangeEnd) must be provided, but not both.',
+          );
+        }
+
+        if (unitStatus) {
+          params.unitStatus = unitStatus;
+        } else if (unitStatusList) {
+          params.unitStatusList = unitStatusList;
+        }
+
+        if (unitType) {
+          params.unitType = unitType;
+        } else if (unitTypeList) {
+          params.unitTypeList = unitTypeList;
+        }
+
+        if (vintageYear) {
+          params.vintageYear = vintageYear;
+        } else if (vintageYearRangeStart && vintageYearRangeEnd) {
+          params.vintageYearRangeStart = vintageYearRangeStart;
+          params.vintageYearRangeEnd = vintageYearRangeEnd;
+        }
+
+        return {
+          url: `/v1/statistics/tonsCo2`,
+          params,
+          method: 'GET',
+        };
+      },
+      keepUnusedDataFor: 600,
+    }),
+  }),
+});
+
+export const { useGetTonsCo2Query } = tonsCo2Api;

--- a/src/renderer/components/blocks/charts/BarChart.tsx
+++ b/src/renderer/components/blocks/charts/BarChart.tsx
@@ -1,4 +1,4 @@
-import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, Plugin } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
@@ -11,12 +11,13 @@ interface BarChartProps {
       data: number[];
     }[];
   };
+  plugins?: Plugin<'bar'>[];
   options?: any;
   className?: string;
 }
 
-const BarChart: React.FC<BarChartProps> = ({ data, options, className }) => {
-  return <Bar data={data} options={options} className={className} />;
+const BarChart: React.FC<BarChartProps> = ({ data, options, className, plugins }) => {
+  return <Bar data={data} options={options} className={className} plugins={plugins} />;
 };
 
 export { BarChart };

--- a/src/renderer/components/blocks/charts/BarChart.tsx
+++ b/src/renderer/components/blocks/charts/BarChart.tsx
@@ -9,15 +9,14 @@ interface BarChartProps {
     datasets: {
       label: string;
       data: number[];
-      backgroundColor: string[];
-      borderWidth: number;
     }[];
   };
   options?: any;
+  className?: string;
 }
 
-const BarChart: React.FC<BarChartProps> = ({ data, options }) => {
-  return <Bar data={data} options={options} />;
+const BarChart: React.FC<BarChartProps> = ({ data, options, className }) => {
+  return <Bar data={data} options={options} className={className} />;
 };
 
 export { BarChart };

--- a/src/renderer/components/blocks/charts/PieChart.tsx
+++ b/src/renderer/components/blocks/charts/PieChart.tsx
@@ -1,4 +1,4 @@
-import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend, Plugin } from 'chart.js';
 import { Pie } from 'react-chartjs-2';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
@@ -11,12 +11,13 @@ interface PieChartProps {
       data: number[];
     }[];
   };
+  plugins?: Plugin<'pie'>[];
   options?: any;
   className?: string;
 }
 
-const PieChart: React.FC<PieChartProps> = ({ data, options, className }) => {
-  return <Pie data={data} options={options} className={className} />;
+const PieChart: React.FC<PieChartProps> = ({ data, options, className, plugins }) => {
+  return <Pie data={data} options={options} className={className} plugins={plugins} />;
 };
 
 export { PieChart };

--- a/src/renderer/components/blocks/charts/PieChart.tsx
+++ b/src/renderer/components/blocks/charts/PieChart.tsx
@@ -14,10 +14,11 @@ interface PieChartProps {
     }[];
   };
   options?: any;
+  className?: string;
 }
 
-const PieChart: React.FC<PieChartProps> = ({ data, options }) => {
-  return <Pie data={data} options={options} />;
+const PieChart: React.FC<PieChartProps> = ({ data, options, className }) => {
+  return <Pie data={data} options={options} className={className} />;
 };
 
 export { PieChart };

--- a/src/renderer/components/blocks/charts/PieChart.tsx
+++ b/src/renderer/components/blocks/charts/PieChart.tsx
@@ -9,8 +9,6 @@ interface PieChartProps {
     datasets: {
       label: string;
       data: number[];
-      backgroundColor: string[];
-      borderWidth: number;
     }[];
   };
   options?: any;

--- a/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
+++ b/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
@@ -1,16 +1,18 @@
 import { useGetTonsCo2Query } from '@/api/cadt/v1/tonsCo2.api';
 import { PieChart, Card, SkeletonCard, Select } from '@/components';
 import { useQueryParamState } from '@/hooks';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
-import { createChartDataWithSingleDataset, pieChartOptionsBase } from '@/utils/chart-utils';
+import { createChartDataWithSingleDataset, createNoDataPlugin, pieChartOptionsBase } from '@/utils/chart-utils';
 import { generateYearsRange } from '@/utils/date-utils';
+import { capitalizeText } from '@/utils/text-utils';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 const CarbonCreditByStatusChart: React.FC = () => {
   const [unitStatus] = useQueryParamState('carbonCreditUnitStatus', 'all');
   const [vintageYear, setVintageYear] = useQueryParamState('vintageYear', undefined);
+  const intl: IntlShape = useIntl();
 
   const {
     data: carbonCreditByStatusData,
@@ -60,10 +62,11 @@ const CarbonCreditByStatusChart: React.FC = () => {
             ...pieChartOptionsBase.plugins,
             title: {
               ...pieChartOptionsBase.plugins.title,
-              text: 'Carbon Credits by Status',
+              text: capitalizeText(intl.formatMessage({ id: 'carbon-credits-by-status' })),
             },
           },
         }}
+        plugins={[createNoDataPlugin(intl)]}
       />
     </Card>
   );

--- a/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
+++ b/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
@@ -8,7 +8,7 @@ import { generateYearsRange } from '@/utils/date-utils';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
-const CarbonCreditByStatusChart = () => {
+const CarbonCreditByStatusChart: React.FC = () => {
   const [unitStatus] = useQueryParamState('carbonCreditUnitStatus', 'all');
   const [vintageYear, setVintageYear] = useQueryParamState('vintageYear', undefined);
 

--- a/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
+++ b/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
@@ -24,8 +24,8 @@ const CarbonCreditByStatusChart: React.FC = () => {
   const datasetData = carbonCreditByStatusData?.data.map((item: any) => item.tonsCo2) || [];
   const chartData = createChartDataWithSingleDataset(labels, datasetData, 'TonsCo2');
 
-  const handleYearChange = (value) => {
-    setVintageYear(value);
+  const handleYearChange = (value: string | number) => {
+    setVintageYear(value as string);
   };
 
   if (carbonCreditByStatusLoading) {

--- a/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
+++ b/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
@@ -3,44 +3,27 @@ import { PieChart, Card, SkeletonCard, Select } from '@/components';
 import { useQueryParamState } from '@/hooks';
 import { FormattedMessage } from 'react-intl';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
-import { generatePieChartData, pieChartOptionsBase } from '@/utils/chart-utils';
-import { useEffect, useState } from 'react';
+import { createChartDataWithSingleDataset, pieChartOptionsBase } from '@/utils/chart-utils';
+import { generateYearsRange } from '@/utils/date-utils';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
-const borderColors = ['rgba(75, 192, 192, 1)', 'rgba(0, 43, 73, 1)', 'rgba(0, 103, 160, 1)'];
-const backgroundColors = ['rgba(75, 192, 192, 0.7)', 'rgba(0, 43, 73, 0.7)', 'rgba(0, 103, 160, 0.7)'];
-
-const generateLastTenYears = (): { label: string; value: string }[] => {
-  const currentYear = `${new Date().getFullYear()}`;
-  return Array.from({ length: 10 }, (_, index) => {
-    const year = parseInt(currentYear) - index;
-    return { label: year.toString(), value: `${year}` };
-  });
-};
 
 const CarbonCreditByStatusChart = () => {
-  const [unitStatus] = useQueryParamState('unitStatus', 'all');
-  const [vintageYear] = useQueryParamState('vintageYear', undefined);
-  const [selectedYear, setSelectedYear] = useState<string>(`${new Date().getFullYear()}`);
+  const [unitStatus] = useQueryParamState('carbonCreditUnitStatus', 'all');
+  const [vintageYear, setVintageYear] = useQueryParamState('vintageYear', undefined);
 
   const {
     data: carbonCreditByStatusData,
     isLoading: carbonCreditByStatusLoading,
     error: carbonCreditByStatusError,
-  } = useGetTonsCo2Query({ unitStatus, vintageYear: selectedYear });
-
-  useEffect(() => {
-    if (vintageYear) {
-      setSelectedYear(vintageYear);
-    }
-  }, [vintageYear]);
+  } = useGetTonsCo2Query({ unitStatus, vintageYear });
 
   const labels = carbonCreditByStatusData?.data.map((item: any) => item.unitStatus) || [];
   const datasetData = carbonCreditByStatusData?.data.map((item: any) => item.tonsCo2) || [];
-  const chartData = generatePieChartData(labels, datasetData, backgroundColors, borderColors, 'TonsCo2');
+  const chartData = createChartDataWithSingleDataset(labels, datasetData, 'TonsCo2');
 
   const handleYearChange = (value) => {
-    setSelectedYear(value);
+    setVintageYear(value);
   };
 
   if (carbonCreditByStatusLoading) {
@@ -65,11 +48,8 @@ const CarbonCreditByStatusChart = () => {
 
   return (
     <Card>
-      <p className="capitalize">
-        <FormattedMessage id={'carbon-credits-by-status'} />
-      </p>
       <div className="grid justify-end">
-        <Select name="year" options={generateLastTenYears()} initialValue={selectedYear} onChange={handleYearChange} />
+        <Select name="year" options={generateYearsRange(10)} initialValue={vintageYear} onChange={handleYearChange} />
       </div>
       <PieChart
         className="max-h-[450px]"
@@ -79,7 +59,7 @@ const CarbonCreditByStatusChart = () => {
           plugins: {
             ...pieChartOptionsBase.plugins,
             title: {
-              display: false,
+              ...pieChartOptionsBase.plugins.title,
               text: 'Carbon Credits by Status',
             },
           },

--- a/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
+++ b/src/renderer/components/blocks/layout/CarbonCreditByStatusChart.tsx
@@ -1,0 +1,92 @@
+import { useGetTonsCo2Query } from '@/api/cadt/v1/tonsCo2.api';
+import { PieChart, Card, SkeletonCard, Select } from '@/components';
+import { useQueryParamState } from '@/hooks';
+import { FormattedMessage } from 'react-intl';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+import { generatePieChartData, pieChartOptionsBase } from '@/utils/chart-utils';
+import { useEffect, useState } from 'react';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+const borderColors = ['rgba(75, 192, 192, 1)', 'rgba(0, 43, 73, 1)', 'rgba(0, 103, 160, 1)'];
+const backgroundColors = ['rgba(75, 192, 192, 0.7)', 'rgba(0, 43, 73, 0.7)', 'rgba(0, 103, 160, 0.7)'];
+
+const generateLastTenYears = (): { label: string; value: string }[] => {
+  const currentYear = `${new Date().getFullYear()}`;
+  return Array.from({ length: 10 }, (_, index) => {
+    const year = parseInt(currentYear) - index;
+    return { label: year.toString(), value: `${year}` };
+  });
+};
+
+const CarbonCreditByStatusChart = () => {
+  const [unitStatus] = useQueryParamState('unitStatus', 'all');
+  const [vintageYear] = useQueryParamState('vintageYear', undefined);
+  const [selectedYear, setSelectedYear] = useState<string>(`${new Date().getFullYear()}`);
+
+  const {
+    data: carbonCreditByStatusData,
+    isLoading: carbonCreditByStatusLoading,
+    error: carbonCreditByStatusError,
+  } = useGetTonsCo2Query({ unitStatus, vintageYear: selectedYear });
+
+  useEffect(() => {
+    if (vintageYear) {
+      setSelectedYear(vintageYear);
+    }
+  }, [vintageYear]);
+
+  const labels = carbonCreditByStatusData?.data.map((item: any) => item.unitStatus) || [];
+  const datasetData = carbonCreditByStatusData?.data.map((item: any) => item.tonsCo2) || [];
+  const chartData = generatePieChartData(labels, datasetData, backgroundColors, borderColors, 'TonsCo2');
+
+  const handleYearChange = (value) => {
+    setSelectedYear(value);
+  };
+
+  if (carbonCreditByStatusLoading) {
+    return <SkeletonCard />;
+  }
+
+  if (carbonCreditByStatusError) {
+    return (
+      <p className="capitalize">
+        <FormattedMessage id={'unable-to-load-contents'} />
+      </p>
+    );
+  }
+
+  if (!carbonCreditByStatusData) {
+    return (
+      <p className="capitalize">
+        <FormattedMessage id={'no-records-found'} />
+      </p>
+    );
+  }
+
+  return (
+    <Card>
+      <p className="capitalize">
+        <FormattedMessage id={'carbon-credits-by-status'} />
+      </p>
+      <div className="grid justify-end">
+        <Select name="year" options={generateLastTenYears()} initialValue={selectedYear} onChange={handleYearChange} />
+      </div>
+      <PieChart
+        className="max-h-[450px]"
+        data={chartData}
+        options={{
+          ...pieChartOptionsBase,
+          plugins: {
+            ...pieChartOptionsBase.plugins,
+            title: {
+              display: false,
+              text: 'Carbon Credits by Status',
+            },
+          },
+        }}
+      />
+    </Card>
+  );
+};
+
+export { CarbonCreditByStatusChart };

--- a/src/renderer/components/blocks/layout/HomeOrgProjectsCountChart.tsx
+++ b/src/renderer/components/blocks/layout/HomeOrgProjectsCountChart.tsx
@@ -7,6 +7,8 @@ import { FormattedMessage } from 'react-intl';
 import { ProjectsHostedCount } from '@/schemas/ProjectsHostedCount.schema';
 
 Chart.register(ChartDataLabels);
+const backgroundColors = ['rgba(83, 217, 217, 0.7)', 'rgba(0, 43, 73, 0.7)'];
+const borderColors = ['#53D9D9', '#002B49'];
 
 const HomeOrgProjectsCountChart = () => {
   const {
@@ -44,6 +46,9 @@ const HomeOrgProjectsCountChart = () => {
   const chartData = generatePieChartData(
     ['Externally Hosted Projects', 'Self Hosted Projects'],
     [externallyHostedCount, selfHostedCount],
+    backgroundColors,
+    borderColors,
+    'Count',
   );
 
   return (

--- a/src/renderer/components/blocks/layout/HomeOrgProjectsCountChart.tsx
+++ b/src/renderer/components/blocks/layout/HomeOrgProjectsCountChart.tsx
@@ -1,14 +1,12 @@
 import { Card, PieChart, SkeletonCard } from '@/components';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { Chart } from 'chart.js';
-import { generatePieChartData, pieChartOptionsBase } from '@/utils/chart-utils';
+import { createChartDataWithSingleDataset, pieChartOptionsBase } from '@/utils/chart-utils';
 import { useGetProjectsCountQuery } from '@/api';
 import { FormattedMessage } from 'react-intl';
 import { ProjectsHostedCount } from '@/schemas/ProjectsHostedCount.schema';
 
 Chart.register(ChartDataLabels);
-const backgroundColors = ['rgba(83, 217, 217, 0.7)', 'rgba(0, 43, 73, 0.7)'];
-const borderColors = ['#53D9D9', '#002B49'];
 
 const HomeOrgProjectsCountChart = () => {
   const {
@@ -43,11 +41,9 @@ const HomeOrgProjectsCountChart = () => {
   const selfHostedCount = hostedCountData.selfHostedProjectCount || 0;
   const externallyHostedCount = hostedCountData.externallyHostedProjectCount || 0;
 
-  const chartData = generatePieChartData(
+  const chartData = createChartDataWithSingleDataset(
     ['Externally Hosted Projects', 'Self Hosted Projects'],
     [externallyHostedCount, selfHostedCount],
-    backgroundColors,
-    borderColors,
     'Count',
   );
 

--- a/src/renderer/components/blocks/layout/IssuedCarbonByMethodologyChart.tsx
+++ b/src/renderer/components/blocks/layout/IssuedCarbonByMethodologyChart.tsx
@@ -1,7 +1,7 @@
 import { BarChart, Card, SkeletonCard } from '@/components';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { Chart } from 'chart.js';
-import { barChartOptionsBase, generateBarChartData } from '@/utils/chart-utils';
+import { barChartOptionsBase, createChartDataWithSingleDataset } from '@/utils/chart-utils';
 import { useGetIssuedCarbonByMethodologyQuery } from '@/api';
 import { FormattedMessage } from 'react-intl';
 
@@ -34,7 +34,19 @@ const IssuedCarbonByMethodologyChart = () => {
     );
   }
 
-  const chartData = generateBarChartData(issuedCarbonByMethodologyData.data.issuedTonsCo2, 'methodology');
+  const filteredData = issuedCarbonByMethodologyData.data.issuedTonsCo2
+    .filter((item) => item.tonsCo2 > 0 && item.methodology)
+    .sort((a, b) => b.tonsCo2 - a.tonsCo2)
+    .slice(0, 3);
+
+  const labels = filteredData.map((item) => {
+    const label = item.methodology || '';
+    return label.length > 35 ? label.slice(0, 35) + '...' : label;
+  });
+
+  const chartDataArray = filteredData.map((item) => item.tonsCo2);
+
+  const chartData = createChartDataWithSingleDataset(labels, chartDataArray, 'tonsCo2');
 
   return (
     <Card>

--- a/src/renderer/components/blocks/layout/IssuedCarbonByMethodologyChart.tsx
+++ b/src/renderer/components/blocks/layout/IssuedCarbonByMethodologyChart.tsx
@@ -39,9 +39,9 @@ const IssuedCarbonByMethodologyChart = () => {
     .sort((a, b) => b.tonsCo2 - a.tonsCo2)
     .slice(0, 3);
 
-  const labels = filteredData.map((item) => {
-    const label = item.methodology || '';
-    return label.length > 35 ? label.slice(0, 35) + '...' : label;
+  const labels = filteredData?.map((item) => {
+    const label = item?.methodology || '';
+    return label?.length > 35 ? label.slice(0, 35) + '...' : label;
   });
 
   const chartDataArray = filteredData.map((item) => item.tonsCo2);

--- a/src/renderer/components/blocks/layout/IssuedCarbonByProjectTypeChart.tsx
+++ b/src/renderer/components/blocks/layout/IssuedCarbonByProjectTypeChart.tsx
@@ -1,7 +1,7 @@
 import { BarChart, Card, SkeletonCard } from '@/components';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { Chart } from 'chart.js';
-import { barChartOptionsBase, generateBarChartData } from '@/utils/chart-utils';
+import { barChartOptionsBase, createChartDataWithSingleDataset } from '@/utils/chart-utils';
 import { useGetIssuedCarbonByProjectTypeQuery } from '@/api';
 import { FormattedMessage } from 'react-intl';
 
@@ -34,7 +34,19 @@ const IssuedCarbonByProjectTypeChart = () => {
     );
   }
 
-  const chartData = generateBarChartData(issuedCarbonByProjectTypeData.data.issuedTonsCo2, 'projectType');
+  const filteredData = issuedCarbonByProjectTypeData.data.issuedTonsCo2
+    .filter((item) => item.tonsCo2 > 0 && item.projectType)
+    .sort((a, b) => b.tonsCo2 - a.tonsCo2)
+    .slice(0, 3);
+
+  const labels = filteredData.map((item) => {
+    const label = item.projectType || '';
+    return label.length > 35 ? label.slice(0, 35) + '...' : label;
+  });
+
+  const chartDataArray = filteredData.map((item) => item.tonsCo2);
+
+  const chartData = createChartDataWithSingleDataset(labels, chartDataArray, 'tonsCo2');
 
   return (
     <Card>

--- a/src/renderer/components/blocks/layout/IssuedCarbonByProjectTypeChart.tsx
+++ b/src/renderer/components/blocks/layout/IssuedCarbonByProjectTypeChart.tsx
@@ -39,9 +39,9 @@ const IssuedCarbonByProjectTypeChart = () => {
     .sort((a, b) => b.tonsCo2 - a.tonsCo2)
     .slice(0, 3);
 
-  const labels = filteredData.map((item) => {
-    const label = item.projectType || '';
-    return label.length > 35 ? label.slice(0, 35) + '...' : label;
+  const labels = filteredData?.map((item) => {
+    const label = item?.projectType || '';
+    return label?.length > 35 ? label.slice(0, 35) + '...' : label;
   });
 
   const chartDataArray = filteredData.map((item) => item.tonsCo2);

--- a/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
+++ b/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
@@ -3,10 +3,15 @@ import { BarChart, Card, Select, SkeletonCard } from '@/components';
 import { useQueryParamState } from '@/hooks';
 import { FormattedMessage } from 'react-intl';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
-import { createChartDataWithMultipleDatasets, stackedBarChartOptionsBase } from '@/utils/chart-utils';
+import {
+  createChartDataWithMultipleDatasets,
+  createNoDataPlugin,
+  stackedBarChartOptionsBase,
+} from '@/utils/chart-utils';
 import { TonsCo2 } from '@/schemas/TonsCo2.schema';
 import { generateYearsRange } from '@/utils/date-utils';
 import { IntlShape, useIntl } from 'react-intl';
+import { capitalizeText } from '@/utils/text-utils';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
@@ -107,10 +112,11 @@ const IssuedCarbonYearlyChart: React.FC = () => {
             ...stackedBarChartOptionsBase.plugins,
             title: {
               ...stackedBarChartOptionsBase,
-              text: 'Issued Carbon (Last 10 years)',
+              text: capitalizeText(intl.formatMessage({ id: 'issued-carbon-last-10-years' })),
             },
           },
         }}
+        plugins={[createNoDataPlugin(intl)]}
       />
     </Card>
   );

--- a/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
+++ b/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
@@ -1,0 +1,117 @@
+import { useGetTonsCo2Query } from '@/api/cadt/v1/tonsCo2.api';
+import { BarChart, Card, Select, SkeletonCard } from '@/components';
+import { useQueryParamState } from '@/hooks';
+import { FormattedMessage } from 'react-intl';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+import { createChartDataWithMultipleDatasets, stackedBarChartOptionsBase } from '@/utils/chart-utils';
+import { TonsCo2 } from '@/schemas/TonsCo2.schema';
+import { generateYearsRange } from '@/utils/date-utils';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+const processCarbonDataByYearAndType = (data: TonsCo2[], unitStatus: string | undefined, unitType: string) => {
+  const groupedData: Record<string, Record<string, number>> = {};
+  data.forEach((item) => {
+    const isUnitStatusMatch = item.unitStatus === unitStatus;
+    const isUnitTypeMatch = unitType === 'all' || item.unitType === unitType;
+    if ((!unitStatus || isUnitStatusMatch) && isUnitTypeMatch) {
+      const { vintageYear, unitType, tonsCo2 } = item;
+      if (vintageYear && !groupedData[vintageYear]) {
+        groupedData[vintageYear] = {};
+      }
+      if (vintageYear && unitType && !groupedData[vintageYear][unitType]) {
+        groupedData[vintageYear][unitType] = 0;
+      }
+      if (vintageYear && unitType && tonsCo2) {
+        groupedData[vintageYear][unitType] += tonsCo2;
+      }
+    }
+  });
+
+  return groupedData;
+};
+
+const unitStatusOptions = [
+  { label: 'Retired', value: 'Retired' },
+  { label: 'Held', value: 'Held' },
+  { label: 'Cancelled', value: 'Cancelled' },
+];
+
+const IssuedCarbonYearlyChart = () => {
+  const [vintageYearRangeStart] = useQueryParamState('vintageYearRangeStart', `${new Date().getFullYear() - 9}`);
+  const [vintageYearRangeEnd] = useQueryParamState('vintageYearRangeEnd', `${new Date().getFullYear()}`);
+  const [unitStatus, setUnitStatus] = useQueryParamState('issuedCarbonUnitStatus', undefined);
+  const [unitType] = useQueryParamState('unitType', 'all');
+
+  const {
+    data: carbonCreditByStatusData,
+    isLoading: carbonCreditByStatusLoading,
+    error: carbonCreditByStatusError,
+  } = useGetTonsCo2Query({ unitType, vintageYearRangeStart, vintageYearRangeEnd, unitStatus });
+
+  if (carbonCreditByStatusLoading) {
+    return <SkeletonCard />;
+  }
+
+  if (carbonCreditByStatusError) {
+    return (
+      <p className="capitalize">
+        <FormattedMessage id={'unable-to-load-contents'} />
+      </p>
+    );
+  }
+
+  if (!carbonCreditByStatusData) {
+    return (
+      <p className="capitalize">
+        <FormattedMessage id={'no-records-found'} />
+      </p>
+    );
+  }
+
+  const lastTenYears = generateYearsRange(10)
+    .map((year) => year.label)
+    .reverse();
+  const carbonData = processCarbonDataByYearAndType(carbonCreditByStatusData.data, unitStatus, unitType);
+
+  const unitTypes = Array.from(
+    new Set(carbonCreditByStatusData.data.map((item) => item.unitType).filter((item) => Boolean(item))),
+  ) as string[];
+
+  const datasets = unitTypes.map((type) => ({
+    label: type,
+    data: lastTenYears.map((year) => carbonData[year]?.[type] || 0),
+  }));
+
+  const chartData2 = createChartDataWithMultipleDatasets(lastTenYears, datasets);
+
+  return (
+    <Card>
+      <div className="grid justify-end">
+        <Select
+          name="status"
+          options={unitStatusOptions}
+          initialValue={unitStatus}
+          onChange={(value) => {
+            setUnitStatus(String(value));
+          }}
+        />
+      </div>
+      <BarChart
+        data={chartData2}
+        options={{
+          ...stackedBarChartOptionsBase,
+          plugins: {
+            ...stackedBarChartOptionsBase.plugins,
+            title: {
+              ...stackedBarChartOptionsBase,
+              text: 'Issued Carbon (Last 10 years)',
+            },
+          },
+        }}
+      />
+    </Card>
+  );
+};
+
+export { IssuedCarbonYearlyChart };

--- a/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
+++ b/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
@@ -6,6 +6,7 @@ import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { createChartDataWithMultipleDatasets, stackedBarChartOptionsBase } from '@/utils/chart-utils';
 import { TonsCo2 } from '@/schemas/TonsCo2.schema';
 import { generateYearsRange } from '@/utils/date-utils';
+import { IntlShape, useIntl } from 'react-intl';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
@@ -31,17 +32,12 @@ const processCarbonDataByYearAndType = (data: TonsCo2[], unitStatus: string | un
   return groupedData;
 };
 
-const unitStatusOptions = [
-  { label: 'Retired', value: 'Retired' },
-  { label: 'Held', value: 'Held' },
-  { label: 'Cancelled', value: 'Cancelled' },
-];
-
 const IssuedCarbonYearlyChart: React.FC = () => {
   const [vintageYearRangeStart] = useQueryParamState('vintageYearRangeStart', `${new Date().getFullYear() - 9}`);
   const [vintageYearRangeEnd] = useQueryParamState('vintageYearRangeEnd', `${new Date().getFullYear()}`);
   const [unitStatus, setUnitStatus] = useQueryParamState('issuedCarbonUnitStatus', undefined);
   const [unitType] = useQueryParamState('unitType', 'all');
+  const intl: IntlShape = useIntl();
 
   const {
     data: carbonCreditByStatusData,
@@ -68,6 +64,12 @@ const IssuedCarbonYearlyChart: React.FC = () => {
       </p>
     );
   }
+
+  const unitStatusOptions = [
+    { label: intl.formatMessage({ id: 'retired' }), value: 'Retired' },
+    { label: intl.formatMessage({ id: 'held' }), value: 'Held' },
+    { label: intl.formatMessage({ id: 'cancelled' }), value: 'Cancelled' },
+  ];
 
   const lastTenYears = generateYearsRange(10)
     .map((year) => year.label)

--- a/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
+++ b/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
@@ -37,7 +37,7 @@ const unitStatusOptions = [
   { label: 'Cancelled', value: 'Cancelled' },
 ];
 
-const IssuedCarbonYearlyChart = () => {
+const IssuedCarbonYearlyChart: React.FC = () => {
   const [vintageYearRangeStart] = useQueryParamState('vintageYearRangeStart', `${new Date().getFullYear() - 9}`);
   const [vintageYearRangeEnd] = useQueryParamState('vintageYearRangeEnd', `${new Date().getFullYear()}`);
   const [unitStatus, setUnitStatus] = useQueryParamState('issuedCarbonUnitStatus', undefined);

--- a/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
+++ b/src/renderer/components/blocks/layout/IssuedCarbonYearlyChart.tsx
@@ -71,9 +71,9 @@ const IssuedCarbonYearlyChart: React.FC = () => {
   }
 
   const unitStatusOptions = [
-    { label: intl.formatMessage({ id: 'retired' }), value: 'Retired' },
-    { label: intl.formatMessage({ id: 'held' }), value: 'Held' },
-    { label: intl.formatMessage({ id: 'cancelled' }), value: 'Cancelled' },
+    { label: capitalizeText(intl.formatMessage({ id: 'retired' })), value: 'Retired' },
+    { label: capitalizeText(intl.formatMessage({ id: 'held' })), value: 'Held' },
+    { label: capitalizeText(intl.formatMessage({ id: 'cancelled' })), value: 'Cancelled' },
   ];
 
   const lastTenYears = generateYearsRange(10)

--- a/src/renderer/components/blocks/layout/index.ts
+++ b/src/renderer/components/blocks/layout/index.ts
@@ -6,3 +6,4 @@ export * from './ApprovedProjectsCard';
 export * from './IssuedCarbonByMethodologyChart';
 export * from './IssuedCarbonByProjectTypeChart';
 export * from './HomeOrgProjectsCountChart';
+export * from './CarbonCreditByStatusChart';

--- a/src/renderer/components/blocks/layout/index.ts
+++ b/src/renderer/components/blocks/layout/index.ts
@@ -7,3 +7,4 @@ export * from './IssuedCarbonByMethodologyChart';
 export * from './IssuedCarbonByProjectTypeChart';
 export * from './HomeOrgProjectsCountChart';
 export * from './CarbonCreditByStatusChart';
+export * from './IssuedCarbonYearlyChart';

--- a/src/renderer/components/blocks/tabs/UnitsTab.tsx
+++ b/src/renderer/components/blocks/tabs/UnitsTab.tsx
@@ -1,5 +1,13 @@
+import { CarbonCreditByStatusChart } from '@/components';
+
 const UnitsTab = () => {
-  return <div>Units view goes here.</div>;
+  return (
+    <div className="flex flex-col gap-16 m-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 max-h-[500px]">
+        <CarbonCreditByStatusChart />
+      </div>
+    </div>
+  );
 };
 
 export { UnitsTab };

--- a/src/renderer/components/blocks/tabs/UnitsTab.tsx
+++ b/src/renderer/components/blocks/tabs/UnitsTab.tsx
@@ -1,9 +1,10 @@
-import { CarbonCreditByStatusChart } from '@/components';
+import { CarbonCreditByStatusChart, IssuedCarbonYearlyChart } from '@/components';
 
 const UnitsTab = () => {
   return (
     <div className="flex flex-col gap-16 m-4">
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 max-h-[500px]">
+        <IssuedCarbonYearlyChart />
         <CarbonCreditByStatusChart />
       </div>
     </div>

--- a/src/renderer/schemas/TonsCo2.schema.ts
+++ b/src/renderer/schemas/TonsCo2.schema.ts
@@ -1,0 +1,6 @@
+export interface TonsCo2 {
+  tonsCo2?: number;
+  vintageYear?: number;
+  unitStatus?: string;
+  unitType?: string;
+}

--- a/src/renderer/translations/tokens/en-US.json
+++ b/src/renderer/translations/tokens/en-US.json
@@ -209,5 +209,11 @@
   "api-host-loaded-from-configuration": "API host loaded from configuration",
 
   "projects-view": "projects view",
-  "units-view": "units view"
+  "units-view": "units view",
+  "retired": "Retired",
+  "cancelled": "Cancelled",
+  "held": "Held",
+  "issued-carbon-last-10-years": "issued carbon last 10 years",
+  "carbon-credits-by-status": "carbon credits by status",
+  "no-data-available": "no data available"
 }

--- a/src/renderer/translations/tokens/en-US.json
+++ b/src/renderer/translations/tokens/en-US.json
@@ -210,9 +210,9 @@
 
   "projects-view": "projects view",
   "units-view": "units view",
-  "retired": "Retired",
-  "cancelled": "Cancelled",
-  "held": "Held",
+  "retired": "retired",
+  "cancelled": "cancelled",
+  "held": "held",
   "issued-carbon-last-10-years": "issued carbon last 10 years",
   "carbon-credits-by-status": "carbon credits by status",
   "no-data-available": "no data available"

--- a/src/renderer/translations/tokens/en-US.json
+++ b/src/renderer/translations/tokens/en-US.json
@@ -209,6 +209,5 @@
   "api-host-loaded-from-configuration": "API host loaded from configuration",
 
   "projects-view": "projects view",
-  "units-view": "units view",
-  "carbon-credits-by-status": "carbon credits by status"
+  "units-view": "units view"
 }

--- a/src/renderer/translations/tokens/en-US.json
+++ b/src/renderer/translations/tokens/en-US.json
@@ -209,5 +209,6 @@
   "api-host-loaded-from-configuration": "API host loaded from configuration",
 
   "projects-view": "projects view",
-  "units-view": "units view"
+  "units-view": "units view",
+  "carbon-credits-by-status": "carbon credits by status"
 }

--- a/src/renderer/utils/chart-utils.ts
+++ b/src/renderer/utils/chart-utils.ts
@@ -1,3 +1,5 @@
+import { IntlShape } from 'react-intl';
+
 const BORDER_COLORS = ['rgba(75, 192, 192, 1)', 'rgba(0, 43, 73, 1)', 'rgba(0, 103, 160, 1)'];
 const BG_COLORS = ['rgba(75, 192, 192, 0.8)', 'rgba(0, 43, 73, 0.8)', 'rgba(0, 103, 160, 0.8)'];
 
@@ -140,3 +142,23 @@ export const createChartDataWithMultipleDatasets = (
     })),
   };
 };
+
+export const createNoDataPlugin = (intl: IntlShape) => ({
+  id: 'noDataPlugin',
+  afterDatasetsDraw: (chart: any) => {
+    const dataset = chart.data.datasets[0];
+    const ctx = chart.ctx;
+
+    if (dataset.data.length === 0) {
+      const { width, height } = chart;
+      chart.clear();
+      ctx.save();
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.font = '16px sans-serif';
+      ctx.fillStyle = 'gray';
+      ctx.fillText(intl.formatMessage({ id: 'no-data-available' }), width / 2, height / 2);
+      ctx.restore();
+    }
+  },
+});

--- a/src/renderer/utils/chart-utils.ts
+++ b/src/renderer/utils/chart-utils.ts
@@ -50,6 +50,7 @@ export const pieChartOptionsBase = {
     legend: {
       display: true,
     },
+    title: '',
     responsive: true,
     datalabels: {
       color: 'white',
@@ -84,13 +85,32 @@ export const generateBarChartData = (data: { labelKey?: string; tonsCo2: number 
   };
 };
 
-export const generatePieChartData = (labels: string[], data: number[]) => ({
+// export const generatePieChartData = (labels: string[], data: number[]) => ({
+//   labels,
+//   datasets: [
+//     {
+//       label: 'Count',
+//       data,
+//       backgroundColor: PIE_COLORS,
+//       borderWidth: 1,
+//     },
+//   ],
+// });
+
+export const generatePieChartData = (
+  labels: string[],
+  data: number[],
+  backgroundColor: string[],
+  borderColor: string[],
+  datasetLabel: string,
+) => ({
   labels,
   datasets: [
     {
-      label: 'Count',
+      label: datasetLabel,
       data,
-      backgroundColor: PIE_COLORS,
+      backgroundColor,
+      borderColor,
       borderWidth: 1,
     },
   ],

--- a/src/renderer/utils/chart-utils.ts
+++ b/src/renderer/utils/chart-utils.ts
@@ -147,10 +147,11 @@ export const createChartDataWithMultipleDatasets = (
 export const createNoDataPlugin = (intl: IntlShape) => ({
   id: 'noDataPlugin',
   afterDatasetsDraw: (chart: any) => {
-    const dataset = chart.data.datasets[0];
+    const datasets = chart.data.datasets;
     const ctx = chart.ctx;
+    const allDataEmpty = datasets.every((dataset) => dataset.data.length === 0);
 
-    if (dataset.data.length === 0) {
+    if (allDataEmpty) {
       const { width, height } = chart;
       chart.clear();
       ctx.save();

--- a/src/renderer/utils/chart-utils.ts
+++ b/src/renderer/utils/chart-utils.ts
@@ -1,5 +1,5 @@
-export const BAR_COLORS = ['#53D9D9', '#002B49', '#0067A0'];
-export const PIE_COLORS = ['#53D9D9', '#002B49'];
+const BORDER_COLORS = ['rgba(75, 192, 192, 1)', 'rgba(0, 43, 73, 1)', 'rgba(0, 103, 160, 1)'];
+const BG_COLORS = ['rgba(75, 192, 192, 0.8)', 'rgba(0, 43, 73, 0.8)', 'rgba(0, 103, 160, 0.8)'];
 
 export const barChartOptionsBase = {
   indexAxis: 'y',
@@ -50,7 +50,14 @@ export const pieChartOptionsBase = {
     legend: {
       display: true,
     },
-    title: '',
+    title: {
+      display: true,
+      text: '',
+      font: {
+        size: 18,
+      },
+      position: 'bottom',
+    },
     responsive: true,
     datalabels: {
       color: 'white',
@@ -59,59 +66,31 @@ export const pieChartOptionsBase = {
   },
 };
 
-export const generateBarChartData = (data: { labelKey?: string; tonsCo2: number }[], labelKey: string) => {
-  const filtered = data
-    .filter((item) => item.tonsCo2 > 0 && item[labelKey])
-    .sort((a, b) => b.tonsCo2 - a.tonsCo2)
-    .slice(0, 3);
-
-  const labels = filtered.map((item) => {
-    const label = item[labelKey];
-    return label ? (label.length > 35 ? label.slice(0, 35) + '...' : label) : '';
-  });
-
-  const chartData = filtered.map((item) => item.tonsCo2);
-
-  return {
-    labels,
-    datasets: [
-      {
-        label: 'tonsCo2',
-        data: chartData,
-        backgroundColor: BAR_COLORS,
-        borderWidth: 1,
-      },
-    ],
-  };
-};
-
-// export const generatePieChartData = (labels: string[], data: number[]) => ({
-//   labels,
-//   datasets: [
-//     {
-//       label: 'Count',
-//       data,
-//       backgroundColor: PIE_COLORS,
-//       borderWidth: 1,
-//     },
-//   ],
-// });
-
-export const generatePieChartData = (
-  labels: string[],
-  data: number[],
-  backgroundColor: string[],
-  borderColor: string[],
-  datasetLabel: string,
-) => ({
+export const createChartDataWithSingleDataset = (labels: string[], data: any[], datasetLabel: any) => ({
   labels,
   datasets: [
     {
       label: datasetLabel,
       data,
-      backgroundColor,
-      borderColor,
+      backgroundColor: BG_COLORS,
+      borderColor: BORDER_COLORS,
       borderWidth: 1,
     },
   ],
 });
+
+export const createChartDataWithMultipleDatasets = (
+  labels: string[],
+  datasets: Array<{ label: string; data: number[] }>,
+) => {
+  return {
+    labels,
+    datasets: datasets.map((dataset, index) => ({
+      label: dataset.label,
+      data: dataset.data,
+      backgroundColor: BG_COLORS[index % BG_COLORS.length],
+      borderColor: BORDER_COLORS[index % BORDER_COLORS.length],
+      borderWidth: 1,
+    })),
+  };
+};

--- a/src/renderer/utils/chart-utils.ts
+++ b/src/renderer/utils/chart-utils.ts
@@ -66,7 +66,7 @@ export const stackedBarChartOptionsBase = {
       grid: { display: false },
       title: {
         display: true,
-        text: 'Tons of CO2',
+        text: 'Tons CO2',
       },
       ticks: {
         display: false,

--- a/src/renderer/utils/chart-utils.ts
+++ b/src/renderer/utils/chart-utils.ts
@@ -45,6 +45,52 @@ export const barChartOptionsBase = {
   },
 };
 
+export const stackedBarChartOptionsBase = {
+  indexAxis: 'x',
+  scales: {
+    x: {
+      stacked: true,
+      grid: { display: false },
+      title: {
+        display: false,
+      },
+      ticks: {
+        autoSkip: false,
+      },
+    },
+    y: {
+      stacked: true,
+      beginAtZero: true,
+      grid: { display: false },
+      title: {
+        display: true,
+        text: 'Tons of CO2',
+      },
+      ticks: {
+        display: false,
+      },
+    },
+  },
+
+  plugins: {
+    legend: {
+      display: true,
+      position: 'left',
+    },
+    title: {
+      display: true,
+      text: '',
+      font: {
+        size: 18,
+      },
+      position: 'bottom',
+    },
+    datalabels: {
+      display: false,
+    },
+  },
+};
+
 export const pieChartOptionsBase = {
   plugins: {
     legend: {

--- a/src/renderer/utils/chart-utils.ts
+++ b/src/renderer/utils/chart-utils.ts
@@ -1,4 +1,5 @@
 import { IntlShape } from 'react-intl';
+import { capitalizeText } from './text-utils';
 
 const BORDER_COLORS = ['rgba(75, 192, 192, 1)', 'rgba(0, 43, 73, 1)', 'rgba(0, 103, 160, 1)'];
 const BG_COLORS = ['rgba(75, 192, 192, 0.8)', 'rgba(0, 43, 73, 0.8)', 'rgba(0, 103, 160, 0.8)'];
@@ -157,7 +158,7 @@ export const createNoDataPlugin = (intl: IntlShape) => ({
       ctx.textBaseline = 'middle';
       ctx.font = '16px sans-serif';
       ctx.fillStyle = 'gray';
-      ctx.fillText(intl.formatMessage({ id: 'no-data-available' }), width / 2, height / 2);
+      ctx.fillText(capitalizeText(intl.formatMessage({ id: 'no-data-available' })), width / 2, height / 2);
       ctx.restore();
     }
   },

--- a/src/renderer/utils/date-utils.ts
+++ b/src/renderer/utils/date-utils.ts
@@ -1,0 +1,7 @@
+export const generateYearsRange = (numYears: number = 10): { label: string; value: string }[] => {
+  const currentYear = new Date().getFullYear();
+  return Array.from({ length: numYears }, (_, index) => {
+    const year = currentYear - index;
+    return { label: year.toString(), value: year.toString() };
+  });
+};

--- a/src/renderer/utils/text-utils.ts
+++ b/src/renderer/utils/text-utils.ts
@@ -1,0 +1,7 @@
+export const capitalizeText = (text: string) => {
+  return text
+    .toLowerCase()
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};


### PR DESCRIPTION
This PR introduces the _Units View_ page within the Dashboard. The following features have been implemented:

- **Issued Carbon Over Last 10 Years**: A stacked bar chart displaying issued carbon over the last 10 years, segmented by carbon unit type, with a filter option by status.
- **Carbon Credits by Status:** Displays the count of carbon units grouped by status, with a filter option by vintage year.

These features aim to improve user experience, data accessibility and provide users with interactive filtering capabilities.